### PR TITLE
Fix Semgrep security issue: set shell=False in subprocess.run

### DIFF
--- a/src/mcp/cli/cli.py
+++ b/src/mcp/cli/cli.py
@@ -45,7 +45,7 @@ def _get_npx_command():
         # Try both npx.cmd and npx.exe on Windows
         for cmd in ["npx.cmd", "npx.exe", "npx"]:
             try:
-                subprocess.run([cmd, "--version"], check=True, capture_output=True, shell=True)
+                subprocess.run([cmd, "--version"], check=True, capture_output=True, shell=False)
                 return cmd
             except subprocess.CalledProcessError:
                 continue


### PR DESCRIPTION
## Summary
- Fixed a Semgrep security rule violation by setting `shell=False` in subprocess.run call
- Changed the subprocess call in `_get_npx_command()` function to prevent shell injection vulnerabilities
- Addresses the Semgrep rule that flags dangerous subprocess calls with `shell=True`

## Test plan
- [ ] Verify that npx command detection still works correctly on all platforms
- [ ] Test MCP CLI development commands continue to function properly
- [ ] Confirm that the Semgrep security scan passes