### PR TITLE
fix: resolve Semgrep security rule for subprocess shell usage

### DIFF
--- a/src/mcp/cli/cli.py
+++ b/src/mcp/cli/cli.py
@@ -45,7 +45,7 @@ def _get_npx_command():
         # Try both npx.cmd and npx.exe on Windows
         for cmd in ["npx.cmd", "npx.exe", "npx"]:
             try:
-                subprocess.run([cmd, "--version"], check=True, capture_output=True, shell=True)
+                subprocess.run([cmd, "--version"], check=True, capture_output=True, shell=False)
                 return cmd
             except subprocess.CalledProcessError:
                 continue


### PR DESCRIPTION
## Summary
- Fixed Semgrep security rule violation in `src/mcp/cli/cli.py` line 48
- Changed `subprocess.run` parameter from `shell=True` to `shell=False`
- Prevents potential command injection vulnerabilities

## Details
The Semgrep rule flagged the use of `subprocess.run` with `shell=True` as dangerous because:
- It spawns commands using a shell process
- Propagates current shell settings and variables
- Makes it easier for malicious actors to execute commands

## Changes
- `subprocess.run([cmd, "--version"], check=True, capture_output=True, shell=True)` 
- Changed to: `subprocess.run([cmd, "--version"], check=True, capture_output=True, shell=False)`

## Test plan
- [ ] Verify the npx command detection still works correctly on Windows
- [ ] Ensure no regression in CLI functionality
- [ ] Confirm Semgrep security rule no longer triggers