### PR TITLE
fix: disable shell execution in subprocess call for security

### DIFF
--- a/src/mcp/cli/cli.py
+++ b/src/mcp/cli/cli.py
@@ -45,7 +45,7 @@ def _get_npx_command():
         # Try both npx.cmd and npx.exe on Windows
         for cmd in ["npx.cmd", "npx.exe", "npx"]:
             try:
-                subprocess.run([cmd, "--version"], check=True, capture_output=True, shell=True)
+                subprocess.run([cmd, "--version"], check=True, capture_output=True, shell=False)
                 return cmd
             except subprocess.CalledProcessError:
                 continue


### PR DESCRIPTION
## Summary
- Fixed Semgrep security rule violation in `src/mcp/cli/cli.py`
- Changed `subprocess.run()` call from `shell=True` to `shell=False` to prevent shell injection vulnerabilities

## Details
This change addresses a Semgrep rule that flagged dangerous usage of subprocess with `shell=True`. The fix improves security by:

- Preventing shell command injection attacks
- Eliminating propagation of shell settings and variables
- Maintaining the same functionality while improving security posture

## Test Plan
- [ ] Verify existing functionality still works
- [ ] Confirm no shell injection vulnerabilities remain
- [ ] Run existing test suite to ensure no regressions