### PR TITLE
Fix subprocess security vulnerability by disabling shell execution

### DIFF
--- a/src/mcp/cli/cli.py
+++ b/src/mcp/cli/cli.py
@@ -45,7 +45,7 @@ def _get_npx_command():
         # Try both npx.cmd and npx.exe on Windows
         for cmd in ["npx.cmd", "npx.exe", "npx"]:
             try:
-                subprocess.run([cmd, "--version"], check=True, capture_output=True, shell=True)
+                subprocess.run([cmd, "--version"], check=True, capture_output=True, shell=False)
                 return cmd
             except subprocess.CalledProcessError:
                 continue


### PR DESCRIPTION
## Summary
- Fixed subprocess security vulnerability in `_get_npx_command()` function
- Changed `shell=True` to `shell=False` in subprocess.run() call to prevent shell injection attacks

## Details
This PR addresses a Semgrep security rule that flagged the dangerous use of `shell=True` in the subprocess.run() call on line 48 of `src/mcp/cli/cli.py`. Using `shell=True` can propagate current shell settings and variables, making it easier for malicious actors to execute commands.

The fix changes:
```python
subprocess.run([cmd, "--version"], check=True, capture_output=True, shell=True)
```
to:
```python
subprocess.run([cmd, "--version"], check=True, capture_output=True, shell=False)
```

This maintains the same functionality while removing the security vulnerability, as the command is already properly formatted as a list of arguments.

## Test plan
- [ ] Verify that npx command detection still works correctly on all platforms
- [ ] Confirm no regression in CLI functionality
- [ ] Validate that the Semgrep security rule no longer triggers