### PR TITLE
Fix security issue: set shell=False in subprocess.run call

### DIFF
--- a/src/mcp/cli/cli.py
+++ b/src/mcp/cli/cli.py
@@ -45,7 +45,7 @@ def _get_npx_command():
         # Try both npx.cmd and npx.exe on Windows
         for cmd in ["npx.cmd", "npx.exe", "npx"]:
             try:
-                subprocess.run([cmd, "--version"], check=True, capture_output=True, shell=True)
+                subprocess.run([cmd, "--version"], check=True, capture_output=True, shell=False)
                 return cmd
             except subprocess.CalledProcessError:
                 continue


### PR DESCRIPTION
## Summary

This PR addresses a security vulnerability identified by Semgrep rule that flagged dangerous use of `shell=True` with subprocess functions.

## Changes Made

- Changed `subprocess.run()` call in `_get_npx_command()` function from `shell=True` to `shell=False`
- Located in `src/mcp/cli/cli.py` around line 48

## Security Impact

The original code used `shell=True` which is dangerous because:
- It spawns commands using a shell process
- Propagates current shell settings and variables
- Makes it easier for malicious actors to execute commands
- Increases attack surface for shell injection vulnerabilities

The fix maintains the same functionality while eliminating the security risk by using `shell=False` instead.

## Testing

The change should not affect functionality as the subprocess call is already using a list format `[cmd, "--version"]` which is compatible with `shell=False`.

## Compliance

This fix addresses the Semgrep security rule: "Found 'subprocess' function 'run' with 'shell=True'. This is dangerous because this call will spawn the command using a shell process."