### PR TITLE
fix: set shell=False in subprocess.run call for security

### DIFF
--- a/src/mcp/cli/cli.py
+++ b/src/mcp/cli/cli.py
@@ -45,7 +45,7 @@ def _get_npx_command():
         # Try both npx.cmd and npx.exe on Windows
         for cmd in ["npx.cmd", "npx.exe", "npx"]:
             try:
-                subprocess.run([cmd, "--version"], check=True, capture_output=True, shell=True)
+                subprocess.run([cmd, "--version"], check=True, capture_output=True, shell=False)
                 return cmd
             except subprocess.CalledProcessError:
                 continue


### PR DESCRIPTION
## Summary

This PR addresses a Semgrep security rule violation by changing `shell=True` to `shell=False` in a `subprocess.run` call within `src/mcp/cli/cli.py`.

## Changes

- Modified `_get_npx_command()` function in `src/mcp/cli/cli.py`
- Changed `subprocess.run([cmd, "--version"], check=True, capture_output=True, shell=True)` to use `shell=False`

## Security Impact

The original code used `shell=True` which spawns commands using a shell process, propagating current shell settings and variables. This creates a potential security vulnerability as it makes it easier for malicious actors to execute commands. By setting `shell=False`, we eliminate this attack vector while maintaining the same functionality.

## Testing

The change is minimal and maintains the same behavior - the function still checks for npx availability but does so more securely. The command being executed (`[cmd, "--version"]`) is already properly formatted as a list, making `shell=False` the appropriate choice.